### PR TITLE
Fix for Crash in ScintillaWinUI::DrawBit with too large drawingBounds parameter

### DIFF
--- a/WinUIEditor/EditorBaseControl.h
+++ b/WinUIEditor/EditorBaseControl.h
@@ -113,6 +113,7 @@ namespace winrt::WinUIEditor::implementation
 		Windows::UI::Xaml::Application::Suspending_revoker _suspendingRevoker{};
 		void Application_Suspending(Windows::Foundation::IInspectable const &sender, Windows::ApplicationModel::SuspendingEventArgs const &args);
 #endif
+		void UpdateVisibleArea();
 	};
 }
 

--- a/WinUIEditor/MainWrapper.cpp
+++ b/WinUIEditor/MainWrapper.cpp
@@ -167,4 +167,14 @@ namespace WinUIEditor
 	void MainWrapper::SetPositionRelative(Scintilla::Internal::PRectangle rc, Wrapper const &wrapper)
 	{
 	}
+
+	void MainWrapper::SetContainer(winrt::DUX::FrameworkElement const& container)
+	{
+		_container = container;
+	}
+
+	winrt::DUX::FrameworkElement MainWrapper::GetContainer()
+	{
+		return _container;
+	}
 }

--- a/WinUIEditor/MainWrapper.h
+++ b/WinUIEditor/MainWrapper.h
@@ -42,11 +42,16 @@ namespace WinUIEditor
 		void Destroy() override;
 		void SetPositionRelative(Scintilla::Internal::PRectangle rc, Wrapper const &wrapper) override;
 
+		void SetContainer(winrt::DUX::FrameworkElement const& container);
+		winrt::DUX::FrameworkElement MainWrapper::GetContainer();
+
 	private:
 		winrt::DUX::Input::Pointer _lastPointer{ nullptr };
 		winrt::DUX::UIElement _mouseCaptureElement{ nullptr };
 		winrt::DUX::Controls::Primitives::ScrollBar _horizontalScrollBar{ nullptr };
 		winrt::DUX::Controls::Primitives::ScrollBar _verticalScrollBar{ nullptr };
 		bool _captured{ false };
+
+		winrt::DUX::FrameworkElement _container{ nullptr };
 	};
 }

--- a/scintilla/winui/ScintillaWin.cxx
+++ b/scintilla/winui/ScintillaWin.cxx
@@ -2614,7 +2614,7 @@ namespace Scintilla::Internal {
 			paintState = PaintState::painting;
 			paintingAllText = true;
 			// Todo: This is in contradiction with the above paragraph about drawing size. But invalidation results in flickering
-			DrawBit(RECT{ 0, 0, _mainWrapper->Width(), _mainWrapper->Height() });
+			DrawBit(visibleArea); // draw ony visible area, _mainWrapper->Width() & Height() can be too big
 		}
 
 		paintState = PaintState::notPainting;
@@ -2651,7 +2651,7 @@ namespace Scintilla::Internal {
 			_mainWrapper->CreateGraphicsDevices();
 			InvalidateStyleRedraw(); // just Redraw() does not work
 		}
-		else
+		else if (beginDrawHR == S_OK)
 		{
 			const auto &d2dDeviceContext{ _mainWrapper->D2dDeviceContext() };
 
@@ -3201,5 +3201,10 @@ namespace Scintilla::Internal {
 		}
 
 		sisNativeWithD2D->EndDraw();
+	}
+
+	void ScintillaWinUI::SetVisibleArea(LONG x, LONG y, LONG width, LONG height)
+	{
+		visibleArea = RECT{ x, y, width, height };
 	}
 }

--- a/scintilla/winui/ScintillaWin.h
+++ b/scintilla/winui/ScintillaWin.h
@@ -108,6 +108,7 @@ namespace Scintilla::Internal {
 		static sptr_t DirectStatusFunction(sptr_t ptr, UINT iMessage, uptr_t wParam, sptr_t lParam, int *pStatus);
 		sptr_t WndProc(Message iMessage, uptr_t wParam, sptr_t lParam) override;
 
+		void SetVisibleArea(LONG x, LONG y, LONG width, LONG height);
 	private:
 		bool _tsfCore;
 
@@ -281,6 +282,8 @@ namespace Scintilla::Internal {
 		winrt::fire_and_forget DoDragAsync();
 		int CalculateNotifyMessageUtf16Length(Scintilla::Notification const &code, Scintilla::ModificationFlags const &modFlags, bool notifyTsf, const char *text, Scintilla::Position mbLength);
 		sptr_t OnSetDocPointer(uptr_t wParam, sptr_t lParam);
+
+		RECT visibleArea;
 	};
 
 	class CallTipCallback : public ::winrt::implements<CallTipCallback, ::IVirtualSurfaceUpdatesCallbackNative>


### PR DESCRIPTION
Some changes so that Scintilla redraw only the visible portion of the control if a complete redraw is needed in case the painting was aborted (due to a word wrap).
